### PR TITLE
Added support for custom user models (closes #7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ There are different possibilies to hijack an user and communicate with users.
 
 ###  Hijack using the 'Hijack Button' on the admin site
 Go to Users in the admin backend and push the ‘Hijack’ button to hijack an user. This is the default mode and base version 
-of django-hijack. To disable the ‘Hijack’ button on the admin site (by not registrating the HijackUserAdmin) set ``SHOW_HIJACKUSER_IN_ADMIN = False`` in your project settings.
+of django-hijack. To disable the ‘Hijack’ button on the admin site (by not registrating the HijackUserAdmin) set ``SHOW_HIJACKUSER_IN_ADMIN = False`` in your project settings. If you are using a custom user model, you will have to add support for displaying the button yourself to your own `CustomUserAdmin`. Simply mix in the `hijack.admin.HijackUserAdminMixin`, and add `hijack_field` to `list_display`.
 
 
 ### Hijack by calling URLs in the browser's address bar
@@ -99,8 +99,8 @@ You can catch a signal when a superuser logs in as another user. Here is an exam
 * unset_superuser example for signals
 * Store info in user's profile (see #3 comments, Use case: 'Notify users when they were hijacked', see above)
 * "got it" Link in notification to remove notification and flag from session. This is useful if hijack is used to switch between users and HIJACK_NOTIFY_ADMIN is True.
-* Custom user models support, see #7
 * Support for named URLs for the hijack button.
+* Graceful support for custom user models that do not feature username / email
 
 # FAQ, troubleshooting and hints
 

--- a/hijack/admin.py
+++ b/hijack/admin.py
@@ -1,22 +1,34 @@
-from django.contrib.auth.models import User
+from django.core.exceptions import ImproperlyConfigured
 from django.contrib import admin
 from django.contrib.sessions.models import Session
 from django.conf import settings
 from django.contrib.auth.admin import UserAdmin
 
 
-class HijackUserAdmin(UserAdmin):
+class HijackUserAdminMixin(object):
+
+    def hijack_field(self, obj):
+        return '<a href="/hijack/%s/" class="button">Hijack %s</a>' % (str(obj.pk), obj)
+    hijack_field.allow_tags = True
+    hijack_field.short_description = 'Hijack User'
+
+
+class HijackUserAdmin(HijackUserAdminMixin, UserAdmin):
     list_display = ('username', 'email', 'first_name', 'last_name',  'last_login', 'date_joined', 'is_staff', 'hijack_field',)
     list_filter = ('is_staff', 'is_superuser')
     search_fields = ('username', 'first_name', 'last_name', 'email',)
 
-    def hijack_field(self, obj):
-        return '<a href="/hijack/%s/" class="button">Hijack %s</a>' % (str(obj.id), obj.username)
-    hijack_field.allow_tags = True
-    hijack_field.short_description = 'Hijack User'
 
 # By default show a Hijack button in the admin panel for the User model.
 if getattr(settings, "SHOW_HIJACKUSER_IN_ADMIN", True):
+    default_user_model = 'auth.User'
+    custom_user_model = getattr(settings, 'AUTH_USER_MODEL', default_user_model)
+    if custom_user_model != default_user_model:
+        raise ImproperlyConfigured(
+            "`SHOW_HIJACKUSER_IN_ADMIN` does not work with a custom user"
+            " model. Instead, mix in the `HijackUserAdminMixin` yourself")
+    from django.contrib.auth.models import User
+
     admin.site.unregister(User)
     admin.site.register(User, HijackUserAdmin)
 

--- a/hijack/helpers.py
+++ b/hijack/helpers.py
@@ -22,7 +22,7 @@ def login_user(request, user):
     backend = get_backends()[0]
     user.backend = "%s.%s" % (backend.__module__, backend.__class__.__name__)
     login(request, user)
-    post_superuser_login.send(sender=None, user_id=user.id)
+    post_superuser_login.send(sender=None, user_id=user.pk)
     request.session['hijackedBySuperuser'] = True
     request.session.modified = True
     return HttpResponseRedirect(getattr(settings, 'LOGIN_REDIRECT_URL', '/'))
@@ -33,7 +33,7 @@ def logout_user(sender, **kwargs):
     ''' wraps logout signal '''
     user = kwargs['user']
     if hasattr(user, 'id'):
-        post_superuser_logout.send(sender=None, user_id=user.id)
+        post_superuser_logout.send(sender=None, user_id=user.pk)
 
 
 """

--- a/hijack/models.py
+++ b/hijack/models.py
@@ -1,3 +1,5 @@
-"""Just an empty models file to let the testrunner recognize this as app."""
-# from django.db import models
-# from django.utils.translation import ugettext_lazy as _
+try:
+    from django.contrib.auth import get_user_model
+except ImportError:
+    from django.contrib.auth.models import User
+    get_user_model = lambda: User

--- a/hijack/views.py
+++ b/hijack/views.py
@@ -1,24 +1,23 @@
 from django.contrib.admin.views.decorators import staff_member_required
-from django.contrib.auth.models import User
 from django.shortcuts import get_object_or_404
 from django.http import HttpResponseBadRequest
 
-
-from helpers import login_user
+from .models import get_user_model
+from .helpers import login_user
 
 @staff_member_required
 def login_with_id(request, userId):
     if isinstance(userId, int):
         return HttpResponseBadRequest('userId must be an integer value.')
-    user = get_object_or_404(User, pk=userId)
+    user = get_object_or_404(get_user_model(), pk=userId)
     return login_user(request, user)
 
 @staff_member_required
 def login_with_email(request, email):
-    user = get_object_or_404(User, email=email)
+    user = get_object_or_404(get_user_model(), email=email)
     return login_user(request, user)
 
 @staff_member_required
 def login_with_username(request, username):
-    user = get_object_or_404(User, username=username)
+    user = get_object_or_404(get_user_model(), username=username)
     return login_user(request, user)


### PR DESCRIPTION
Note that this adds support for a basic custom user model. This could still be further improved. For example, if the custom model does not feature an email address it is pointless to offer a hijack-by-email url. As this is not a relevant use case for our current project I will not be working on this. I have added this to the TODO list though ...
