### PR TITLE
reverse() in admin and disable hijack warning message

### DIFF
--- a/hijack/admin.py
+++ b/hijack/admin.py
@@ -3,6 +3,7 @@ from django.contrib import admin
 from django.contrib.sessions.models import Session
 from django.conf import settings
 from django.contrib.auth.admin import UserAdmin
+from django.core.urlresolvers import reverse
 
 
 class HijackUserAdmin(UserAdmin):
@@ -11,7 +12,7 @@ class HijackUserAdmin(UserAdmin):
     search_fields = ('username', 'first_name', 'last_name', 'email',)
 
     def hijack_field(self, obj):
-        return '<a href="/hijack/%s/" class="button">Hijack %s</a>' % (str(obj.id), obj.username)
+        return '<a href="%s" class="button">Hijack %s</a>' % (reverse('hijack.views.login_with_id',args=(obj.id,)), obj.username)
         # TODO: use reverse() here 
         
     hijack_field.allow_tags = True

--- a/hijack/templates/hijack/notifications.html
+++ b/hijack/templates/hijack/notifications.html
@@ -1,5 +1,6 @@
 {% load url from future %}
 <div id="hijacked-warning" >
-	Working with hijacked user '{{ request.user.username }}'! <a href="{% url 'release_hijack' %}">release hijacked user</a>
+    Working with hijacked user '{{ request.user.username }}'! <a href="{% url 'release_hijack' %}">release hijacked user</a>
     <button onclick="document.getElementById('hijacked-warning').remove();" style="float: right;margin-right: 10px" >x</button>
+    <a href="{% url 'disable_hijack_warning'  %}?next={{request.path_info}}" style="float: right;margin-right: 10px" >got it</a>    
 </div>

--- a/hijack/urls.py
+++ b/hijack/urls.py
@@ -5,6 +5,7 @@ except ImportError:
 
  
 urlpatterns = patterns('hijack.views',
+    url(r'^disable-hijack-warning/$', 'disable_hijack_warning', name='disable_hijack_warning'),
     url(r'^release-hijack/$', 'release_hijack', name='release_hijack'),
     url(r'^email/(?P<email>[\w.%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,4})/$', 'login_with_email'),
     url(r'^username/(?P<username>\w+)/$', 'login_with_username'),

--- a/hijack/views.py
+++ b/hijack/views.py
@@ -2,7 +2,7 @@ from django.contrib.admin.views.decorators import staff_member_required
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
 from django.shortcuts import get_object_or_404
-from django.http import HttpResponseBadRequest
+from django.http import HttpResponseBadRequest, HttpResponseRedirect
 
 
 from hijack.helpers import login_user
@@ -28,6 +28,12 @@ def login_with_username(request, username):
     user = get_object_or_404(User, username=username)
     return login_user(request, user)
 
+
 @login_required
 def release_hijack(request):
     return release_hijack_fx(request)
+
+
+def disable_hijack_warning(request):
+    request.session['is_hijacked_user']=False
+    return HttpResponseRedirect(request.GET.get('next','/'))


### PR DESCRIPTION
closes #16 and #17
The x button remains, but additionally there is a link to remove the hijack warning for this session

hijack url in admin is dynamic
new link in hijack warning, sets is_hijacked_user in the session to False --> message will not be displayed anymore
