### PR TITLE
Show short_name instead of username in the notification

### DIFF
--- a/hijack/templates/hijack/notifications.html
+++ b/hijack/templates/hijack/notifications.html
@@ -1,5 +1,5 @@
 {% load url from future %}
 <div id="hijacked-warning" >
-    <span style="padding-top: 4px; float: left;"><b>You're currently work on behalf of {{ request.user.get_short_name }}. </b></span>  <span style="float: right; margin-right: 15px;"> <a href="{% url 'release_hijack' %}"  class="django-hijack-button">release {{ request.user.username }}</a>
+    <span style="padding-top: 4px; float: left;"><b>You're currently working on behalf of {{ request.user.get_short_name }}. </b></span>  <span style="float: right; margin-right: 15px;"> <a href="{% url 'release_hijack' %}"  class="django-hijack-button">release {{ request.user.username }}</a>
     <a href="{% url 'disable_hijack_warning'  %}?next={{request.path_info}}" class="django-hijack-button">hide</a> </span>
 </div>


### PR DESCRIPTION
Currently, if your custom user model doesn't use a username field, the notification does not show which account you've hijacked. This change works for both default and custom user models.
