### PR TITLE
Enable to hijack with arbitrary fields.

### DIFF
--- a/hijack/tests/test_hijack.py
+++ b/hijack/tests/test_hijack.py
@@ -30,9 +30,9 @@ class BaseHijackTests(TestCase):
         self.user_username = 'user'
         self.user_email = 'user@example.com'
         self.user_password = 'user_pw'
-        self.user = User.objects.create_user(self.user_username, self.user_email, self.user_password)
+        self.user = User.objects.create_user(self.user_username, self.user_email, self.user_password, first_name='django-hijack')
 
-        User.objects.create_user('user2', 'user2@example.com', 'user_pw')
+        User.objects.create_user('user2', 'user2@example.com', 'user_pw', first_name='django-hijack')
 
         self.client.login(username=self.superuser_username, password=self.superuser_password)
 
@@ -104,7 +104,7 @@ class HijackTests(BaseHijackTests):
         self.assertEqual(response.status_code, 404)
         response = self.client.post('/hijack/user_name/bob/', follow=True)
         self.assertEqual(response.status_code, 404)
-        response = self.client.post('/hijack/password/user_pw/', follow=True)
+        response = self.client.post('/hijack/first_name/django-hijack/', follow=True)
         self.assertEqual(response.status_code, 404)
 
     def test_hijack_url_email(self):

--- a/hijack/tests/test_hijack.py
+++ b/hijack/tests/test_hijack.py
@@ -80,8 +80,8 @@ class HijackTests(BaseHijackTests):
         self.assertEqual('/hijack/release-hijack/', reverse('release_hijack'))
         self.assertEqual('/hijack/1/', reverse('login_with_id', args=[1]))
         self.assertEqual('/hijack/2/', reverse('login_with_id', kwargs={'user_id': 2}))
-        self.assertEqual('/hijack/username/bob/', reverse('login_with_username', args=['bob']))
-        self.assertEqual('/hijack/username/bob_too/', reverse('login_with_username', kwargs={'username': 'bob_too'}))
+        self.assertEqual('/hijack/username/bob/', reverse('login_with_another_field', kwargs={'field': 'username', 'value': 'bob'}))
+        self.assertEqual('/hijack/username/bob_too/', reverse('login_with_another_field', kwargs={'field': 'username', 'value': 'bob_too'}))
         self.assertEqual('/hijack/email/bob@bobsburgers.com/', unquote_plus(reverse('login_with_email', args=['bob@bobsburgers.com'])))
         self.assertEqual('/hijack/email/bob_too@bobsburgers.com/', unquote_plus(reverse('login_with_email', kwargs={'email': 'bob_too@bobsburgers.com'})))
 

--- a/hijack/tests/test_hijack.py
+++ b/hijack/tests/test_hijack.py
@@ -32,6 +32,8 @@ class BaseHijackTests(TestCase):
         self.user_password = 'user_pw'
         self.user = User.objects.create_user(self.user_username, self.user_email, self.user_password)
 
+        User.objects.create_user('user2', 'user2@example.com', 'user_pw')
+
         self.client.login(username=self.superuser_username, password=self.superuser_password)
 
     def tearDown(self):
@@ -94,11 +96,15 @@ class HijackTests(BaseHijackTests):
         response = self.client.post('/hijack/-1/', follow=True)
         self.assertEqual(response.status_code, 404)
 
-    def test_hijack_url_username(self):
-        response = self.client.post('/hijack/username/%s/' % self.user_username, follow=True)
+    def test_hijack_url_another_field(self):
+        response = self.client.post('/hijack/%s/%s/' % ('username', self.user_username), follow=True)
         self.assertHijackSuccess(response)
         self._release_hijack()
         response = self.client.post('/hijack/username/dfjakhdl/', follow=True)
+        self.assertEqual(response.status_code, 404)
+        response = self.client.post('/hijack/user_name/bob/', follow=True)
+        self.assertEqual(response.status_code, 404)
+        response = self.client.post('/hijack/password/user_pw/', follow=True)
         self.assertEqual(response.status_code, 404)
 
     def test_hijack_url_email(self):

--- a/hijack/urls.py
+++ b/hijack/urls.py
@@ -25,15 +25,15 @@ if 'email' in hijacking_user_attributes:
         views.login_with_email,
         name='login_with_email'
     ))
-if 'username' in hijacking_user_attributes:
-    urlpatterns.append(url(
-        r'^username/(?P<username>.*)/$',
-        views.login_with_username,
-        name='login_with_username'
-    ))
 if 'user_id' in hijacking_user_attributes:
     urlpatterns.append(url(
         r'^(?P<user_id>[\w-]+)/$',
         views.login_with_id,
         name='login_with_id'
+    ))
+else:
+    urlpatterns.append(url(
+        r'^(?P<field>[\w]+)/(?P<value>[\w]+)/$',
+        views.login_with_another_field,
+        name=login_with_another_field
     ))

--- a/hijack/urls.py
+++ b/hijack/urls.py
@@ -33,7 +33,7 @@ if 'user_id' in hijacking_user_attributes:
     ))
 if any([e for e in hijacking_user_attributes if e != 'email' or e != 'user_id']):
     urlpatterns.append(url(
-        r'^(?P<field>[\w]+)/(?P<value>[\w]+)/$',
+        r'^(?P<field>[\w-]+)/(?P<value>[\w-]+)/$',
         views.login_with_another_field,
         name='login_with_another_field'
     ))

--- a/hijack/urls.py
+++ b/hijack/urls.py
@@ -31,9 +31,9 @@ if 'user_id' in hijacking_user_attributes:
         views.login_with_id,
         name='login_with_id'
     ))
-else:
+if any([e for e in hijacking_user_attributes if e != 'email' or e != 'user_id']):
     urlpatterns.append(url(
         r'^(?P<field>[\w]+)/(?P<value>[\w]+)/$',
         views.login_with_another_field,
-        name=login_with_another_field
+        name='login_with_another_field'
     ))

--- a/hijack/views.py
+++ b/hijack/views.py
@@ -3,6 +3,7 @@ from django.contrib.auth.decorators import login_required
 from django.http import HttpResponseBadRequest
 from django.shortcuts import get_object_or_404
 from django.http import Http404
+from django.core.exceptions import FieldError, ObjectDoesNotExist, MultipleObjectsReturned
 
 from hijack.decorators import hijack_require_http_methods, hijack_decorator
 from hijack.helpers import login_user, redirect_to_next
@@ -36,13 +37,11 @@ def login_with_another_field(request, field, value):
     try:
         user = get_user_model().objects.get(**{field: value})
     except FieldError:
-        return Http404('There is no such field in your user model.')
-    except DoesNotExist:
-        return Http404('There is no such object that matches the value.')
+        raise Http404('There is no such field in your user model.')
+    except ObjectDoesNotExist:
+        raise Http404('There is no such object that matches the value.')
     except MultipleObjectsReturned:
-        return Http404('There is multiple objects that math the value.')
-    except Exception:
-        return Http404('')
+        raise Http404('There is multiple objects that math the value.')
     return login_user(request, user)
 
 

--- a/hijack/views.py
+++ b/hijack/views.py
@@ -2,6 +2,7 @@
 from django.contrib.auth.decorators import login_required
 from django.http import HttpResponseBadRequest
 from django.shortcuts import get_object_or_404
+from django.http import Http404
 
 from hijack.decorators import hijack_require_http_methods, hijack_decorator
 from hijack.helpers import login_user, redirect_to_next
@@ -31,8 +32,17 @@ def login_with_email(request, email):
 
 @hijack_decorator
 @hijack_require_http_methods
-def login_with_username(request, username):
-    user = get_object_or_404(get_user_model(), username=username)
+def login_with_another_field(request, field, value):
+    try:
+        user = get_user_model().objects.get(**{field: value})
+    except FieldError:
+        return Http404('There is no such field in your user model.')
+    except DoesNotExist:
+        return Http404('There is no such object that matches the value.')
+    except MultipleObjectsReturned:
+        return Http404('There is multiple objects that math the value.')
+    except Exception:
+        return Http404('')
     return login_user(request, user)
 
 


### PR DESCRIPTION
## Why changed
I was reading [documentation](https://django-hijack.readthedocs.io/en/latest/) and realized that I could not hijack with the field that was not `username` but resistered as `USERNAME_FIELD` . 
In addition to this, I think that it is convenient if I can hijack with any field that can identify the user instance.

## Impact range by this PR
We can hijack with any field that can identify the user instance.

## Further Develop
If needed, `email` field can be incorporated into my algorithm.

## Comment
This is my first PR to OSS.
Thank you for any help or comment.