### PR TITLE
Adding pre-hijack and pre-release signals

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -120,11 +120,19 @@ Example screenshot:
 You can catch a signal when someone is hijacked or released. Here is an example:
 
 ```python
-from hijack.signals import hijack_started, hijack_ended
+from hijack.signals import hijack_started, hijack_ended, pre_hijack_started, pre_hijack_ended
+
+def print_pre_hijack_started(sender, hijacker_id, hijacked_id, request, **kwargs):
+    print('%d is about to hijack %d' % (hijacker_id, hijacked_id))
+pre_hijack_started.connect(print_pre_hijack_started)
 
 def print_hijack_started(sender, hijacker_id, hijacked_id, request, **kwargs):
     print('%d has hijacked %d' % (hijacker_id, hijacked_id))
 hijack_started.connect(print_hijack_started)
+
+def print_pre_hijack_ended(sender, hijacker_id, hijacked_id, request, **kwargs):
+    print('%d is about to release %d' % (hijacker_id, hijacked_id))
+pre_hijack_ended.connect(print_pre_hijack_ended)
     
 def print_hijack_ended(sender, hijacker_id, hijacked_id, request, **kwargs):
     print('%d has released %d' % (hijacker_id, hijacked_id))

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -5,4 +5,5 @@ pages:
 - Configuration: configuration.md
 - Troubleshooting: troubleshooting.md
 - About: about.md
+- Signals: signals.md
 theme: readthedocs

--- a/docs/signals.md
+++ b/docs/signals.md
@@ -1,0 +1,74 @@
+# Signals
+
+## Default Parameters
+
+The following signals by default supply the following parameters::
+
+    sender: Currently always None
+    request: The standard request object all views receive.
+    hijacker: The user object doing the hijacking.
+    hijacked: The user object being hijacked and taken over.
+
+## Available Signals
+
+### hijack.signals.pre_hijack_started
+
+Sent BEFORE the hijack occurs. Session data is still for the hijacker.
+
+Data returned from this signal is passed onto `hijack_started`.
+
+### hijack.signals.hijack_started
+
+Sent AFTER the hijack occurs. Session data is now for the hijacked.
+
+In addition to the default parameters mentioned above, this signal also 
+supplies an additional parameter `pre_hijack_started_results`. 
+This parameter contains a list of tuple pairs **[(receiver, response), ... ]**, 
+representing the list of called receiver functions and their response values
+of all other functions called using the `pre_hijack_started` signal.
+
+This additional parameter is useful for when you need to manipulate session data BEFORE 
+a hijack occurs and at the same time passing the results onto the `hijack_started` 
+signal AFTER the hijack has happened.
+
+### hijack.signals.pre_hijack_ended
+    
+Sent BEFORE the hijack ends. Session data is still for the hijacked user.
+
+Data returned from this signal is passed onto `hijack_ended`.
+
+### hijack.signals.hijack_ended
+
+Sent AFTER the hijack ends. Session data is now for the hijacker.
+ 
+This signal also supplies an additional parameter `pre_hijack_ended_results`. 
+This parameter contains a list of tuple pairs **[(receiver, response), ... ]**, 
+representing the list of called receiver functions and their response values
+of all other functions called using the `pre_hijack_ended` signal.
+
+This additional parameter is useful for when you need to manipulate session data BEFORE 
+a hijack ends and at the same time passing the results onto the `hijack_ended` 
+signal AFTER the hijack ends.
+
+ 
+## Examples:
+
+```python
+from hijack.signals import hijack_started, hijack_ended, pre_hijack_started, pre_hijack_ended
+
+def print_pre_hijack_started(sender, hijacker_id, hijacked_id, request, **kwargs):
+    print('%d is about to hijack %d' % (hijacker_id, hijacked_id))
+pre_hijack_started.connect(print_pre_hijack_started)
+
+def print_hijack_started(sender, hijacker_id, hijacked_id, request, **kwargs):
+    print('%d has hijacked %d' % (hijacker_id, hijacked_id))
+hijack_started.connect(print_hijack_started)
+
+def print_pre_hijack_ended(sender, hijacker_id, hijacked_id, request, **kwargs):
+    print('%d is about to release %d' % (hijacker_id, hijacked_id))
+pre_hijack_ended.connect(print_pre_hijack_ended)
+    
+def print_hijack_ended(sender, hijacker_id, hijacked_id, request, **kwargs):
+    print('%d has released %d' % (hijacker_id, hijacked_id))
+hijack_ended.connect(print_hijack_ended)
+```

--- a/hijack/helpers.py
+++ b/hijack/helpers.py
@@ -53,7 +53,7 @@ def release_hijack(request):
     backend = get_used_backend(request)
     hijacker.backend = "%s.%s" % (backend.__module__, backend.__class__.__name__)
 
-    pre_signal_returned_value = pre_hijack_ended.send(
+    pre_hijack_ended_results = pre_hijack_ended.send(
         sender=None, request=request,
         hijacker=hijacker, hijacked=hijacked,
         # send IDs for backward compatibility
@@ -73,7 +73,7 @@ def release_hijack(request):
         hijacker=hijacker, hijacked=hijacked,
         # send IDs for backward compatibility
         hijacker_id=hijacker.pk, hijacked_id=hijacked.pk,
-        pre_hijack_ended_results=pre_signal_returned_value,
+        pre_hijack_ended_results=pre_hijack_ended_results,
     )
 
     return redirect_to_next(request, default_url=hijack_settings.HIJACK_LOGOUT_REDIRECT_URL)
@@ -133,7 +133,7 @@ def login_user(request, hijacked):
     backend = get_used_backend(request)
     hijacked.backend = "%s.%s" % (backend.__module__, backend.__class__.__name__)
 
-    pre_signal_returned_value = pre_hijack_started.send(
+    pre_hijack_started_results = pre_hijack_started.send(
         sender=None, request=request,
         hijacker=hijacker, hijacked=hijacked,
         # send IDs for backward compatibility
@@ -149,7 +149,7 @@ def login_user(request, hijacked):
         hijacker=hijacker, hijacked=hijacked,
         # send IDs for backward compatibility
         hijacker_id=hijacker.pk, hijacked_id=hijacked.pk,
-        pre_hijack_started_results=pre_signal_returned_value
+        pre_hijack_started_results=pre_hijack_started_results
     )
     request.session['hijack_history'] = hijack_history
     request.session['is_hijacked_user'] = True

--- a/hijack/helpers.py
+++ b/hijack/helpers.py
@@ -63,9 +63,15 @@ def release_hijack(request):
     with no_update_last_login():
         login(request, hijacker)
 
-    request.session.pop('hijack_history', None)
-    request.session.pop('is_hijacked_user', None)
-    request.session.pop('display_hijack_warning', None)
+    if hijack_history:
+        request.session['hijack_history'] = hijack_history
+        request.session['is_hijacked_user'] = True
+        request.session['display_hijack_warning'] = True
+    else:
+        request.session.pop('hijack_history', None)
+        request.session.pop('is_hijacked_user', None)
+        request.session.pop('display_hijack_warning', None)
+
     request.session.modified = True
 
     hijack_ended.send(

--- a/hijack/helpers.py
+++ b/hijack/helpers.py
@@ -63,9 +63,9 @@ def release_hijack(request):
     with no_update_last_login():
         login(request, hijacker)
 
-    request.session['hijack_history'] = hijack_history
-    request.session['is_hijacked_user'] = True
-    request.session['display_hijack_warning'] = True
+    request.session.pop('hijack_history', None)
+    request.session.pop('is_hijacked_user', None)
+    request.session.pop('display_hijack_warning', None)
     request.session.modified = True
 
     hijack_ended.send(

--- a/hijack/helpers.py
+++ b/hijack/helpers.py
@@ -73,7 +73,7 @@ def release_hijack(request):
         hijacker=hijacker, hijacked=hijacked,
         # send IDs for backward compatibility
         hijacker_id=hijacker.pk, hijacked_id=hijacked.pk,
-        pre_release_results=pre_signal_returned_value,
+        pre_hijack_ended_results=pre_signal_returned_value,
     )
 
     return redirect_to_next(request, default_url=hijack_settings.HIJACK_LOGOUT_REDIRECT_URL)
@@ -149,7 +149,7 @@ def login_user(request, hijacked):
         hijacker=hijacker, hijacked=hijacked,
         # send IDs for backward compatibility
         hijacker_id=hijacker.pk, hijacked_id=hijacked.pk,
-        pre_hijack_results=pre_signal_returned_value
+        pre_hijack_started_results=pre_signal_returned_value
     )
     request.session['hijack_history'] = hijack_history
     request.session['is_hijacked_user'] = True

--- a/hijack/signals.py
+++ b/hijack/signals.py
@@ -3,3 +3,5 @@ from django.dispatch import Signal
 hijack_started = Signal(providing_args=['hijacker_id', 'hijacked_id', 'request', 'hijacker', 'hijacked'])
 hijack_ended = Signal(providing_args=['hijacker_id', 'hijacked_id', 'request', 'hijacker', 'hijacked'])
 
+pre_hijack_started = Signal(providing_args=['hijacker_id', 'hijacked_id', 'request', 'hijacker', 'hijacked'])
+pre_hijack_ended = Signal(providing_args=['hijacker_id', 'hijacked_id', 'request', 'hijacker', 'hijacked'])

--- a/hijack/signals.py
+++ b/hijack/signals.py
@@ -1,7 +1,7 @@
 from django.dispatch import Signal
 
-hijack_started = Signal(providing_args=['hijacker_id', 'hijacked_id', 'request', 'hijacker', 'hijacked'])
-hijack_ended = Signal(providing_args=['hijacker_id', 'hijacked_id', 'request', 'hijacker', 'hijacked'])
+hijack_started = Signal(providing_args=['hijacker_id', 'hijacked_id', 'request', 'hijacker', 'hijacked', 'pre_hijack_started_results'])
+hijack_ended = Signal(providing_args=['hijacker_id', 'hijacked_id', 'request', 'hijacker', 'hijacked', 'pre_hijack_ended_results'])
 
 pre_hijack_started = Signal(providing_args=['hijacker_id', 'hijacked_id', 'request', 'hijacker', 'hijacked'])
 pre_hijack_ended = Signal(providing_args=['hijacker_id', 'hijacked_id', 'request', 'hijacker', 'hijacked'])

--- a/hijack/tests/test_hijack.py
+++ b/hijack/tests/test_hijack.py
@@ -386,10 +386,10 @@ class HijackTests(BaseHijackTests):
         self.assertEqual(len(received_signals), 0)
         self._hijack(self.user)
         self.assertEqual(len(received_signals), 1)
-        self.assertEqual(received_signals[0], True)
+        self.assertTrue(received_signals[0])
         self._release_hijack()
         self.assertEqual(len(received_signals), 2)
-        self.assertEqual(received_signals[1], True)
+        self.assertTrue(received_signals[1])
 
     def test_custom_session_cookie_name(self):
         self.assertEqual(settings.SESSION_COOKIE_NAME, 'sessionid')


### PR DESCRIPTION
This PR adds 2 new signals similar to djangos pre and post styling.

`pre_hijack_started` occurs before the hijack is applied. `pre_hijack_ended` occurs before the hijack ends. Naming convention should be fairly self-explanatory.

Additionally, a new parameter has been added to the 2 original signals. Namely `hijack_started:pre_hijack_started_results` and `hijack_ended:pre_hijack_ended_results`. The purpose of this new parameter is so that the `pre_*` signals can return data that may be needed after the hijack starts/ends. Django signals documentation states all signals must contain `**kwargs` in their parameters, as such this should not affect existing installations.

My personal usage of this is due to having to store data in a model that pertains to the current users session. The pre signals returns the original session_key value and that is passed into the post signal. From there I store the original session_in the new hijacked session. Upon release another pre/post signal data pass and i reload the session variables and data.