### PR TITLE
Update login_user function to allow passing custom auth and redirect url parameters

### DIFF
--- a/hijack/helpers.py
+++ b/hijack/helpers.py
@@ -116,14 +116,16 @@ def check_hijack_authorization(request, user):
         raise PermissionDenied
 
 
-def login_user(request, hijacked):
+def login_user(request, hijacked, auth_check_function=check_hijack_authorization):
     ''' hijack mechanism '''
     hijacker = request.user
     hijack_history = [request.user._meta.pk.value_to_string(hijacker)]
     if request.session.get('hijack_history'):
         hijack_history = request.session['hijack_history'] + hijack_history
 
-    check_hijack_authorization(request, hijacked)
+    # Allow a developer to override the authorization check, or remove it altogether.
+    if callable(auth_check_function):
+        auth_check_function(request, hijacked)
 
     backend = get_used_backend(request)
     hijacked.backend = "%s.%s" % (backend.__module__, backend.__class__.__name__)

--- a/hijack/helpers.py
+++ b/hijack/helpers.py
@@ -129,6 +129,12 @@ def login_user(request, hijacked,
     if callable(auth_check_function):
         auth_check_function(request, hijacked)
 
+    elif isinstance(auth_check_function, (list, tuple, set)):
+        # Allow someone to pass a list, tuple, or set of various authentication functions to check against.
+        for possible_function in auth_check_function:
+            if callable(possible_function):
+                possible_function(request, hijacked)
+
     backend = get_used_backend(request)
     hijacked.backend = "%s.%s" % (backend.__module__, backend.__class__.__name__)
 

--- a/hijack/helpers.py
+++ b/hijack/helpers.py
@@ -116,7 +116,9 @@ def check_hijack_authorization(request, user):
         raise PermissionDenied
 
 
-def login_user(request, hijacked, auth_check_function=check_hijack_authorization):
+def login_user(request, hijacked,
+               auth_check_function=check_hijack_authorization,
+               redirect_to_url=hijack_settings.HIJACK_LOGIN_REDIRECT_URL):
     ''' hijack mechanism '''
     hijacker = request.user
     hijack_history = [request.user._meta.pk.value_to_string(hijacker)]
@@ -143,7 +145,7 @@ def login_user(request, hijacked, auth_check_function=check_hijack_authorization
     request.session['is_hijacked_user'] = True
     request.session['display_hijack_warning'] = True
     request.session.modified = True
-    return redirect_to_next(request, default_url=hijack_settings.HIJACK_LOGIN_REDIRECT_URL)
+    return redirect_to_next(request, default_url=redirect_to_url)
 
 
 def redirect_to_next(request, default_url=hijack_settings.HIJACK_LOGIN_REDIRECT_URL):

--- a/hijack/tests/test_hijack.py
+++ b/hijack/tests/test_hijack.py
@@ -411,3 +411,22 @@ class HijackTests(BaseHijackTests):
         self.assertFalse(request.session.pop('is_hijacked_user', False))
         self.assertFalse(request.session.pop('display_hijack_warning', False))
         self.assertFalse(request.session.pop('hijack_history', False))
+
+    def test_login_user_redirect_url(self):
+        self.client.logout()
+        self.client.login(username=self.superuser_username, password=self.superuser_password)
+        response = self.client.get('/')
+        request = response.context['request']
+
+        redirect_to_response = login_user(request, self.user)
+        self.assertEqual(redirect_to_response.url, hijack_settings.HIJACK_LOGIN_REDIRECT_URL)
+
+        release_hijack(request)
+
+        redirect_to_response = login_user(request, self.user, redirect_to_url='test_app:hello_filter')
+        self.assertEqual(redirect_to_response.url, reverse('test_app:hello_filter'))
+
+        release_hijack(request)
+
+        redirect_to_response = login_user(request, self.user, redirect_to_url=reverse('test_app:hello_filter'))
+        self.assertEqual(redirect_to_response.url, reverse('test_app:hello_filter'))


### PR DESCRIPTION
The primary function `login_user` that is called to hijack a user does a couple things that could be optional under certain circumstances.

This PR introduces 3 new parameters to login_user: `auth_check_function`, `auth_check_function_all`, and `redirect_to_url`.

`auth_check_function` parameter allows a developer to supply a different authentication checking function in the case that they wish to allow hijacking using something other than the system default. If they pass a list of functions to check against, `auth_check_function_all` is used to determine if all functions must return valid access or if one of many supplied return valid access. For security reasons it defaults to True that all must return valid.

`redirect_to_url` defaults to the original system default of `hijack_settings.HIJACK_LOGIN_REDIRECT_URL` but now allows a developer to supply their own url as well.