### PR TITLE
fix: user_id isn't always an int

### DIFF
--- a/hijack/views.py
+++ b/hijack/views.py
@@ -13,11 +13,6 @@ from compat import get_user_model
 @hijack_decorator
 @hijack_require_http_methods
 def login_with_id(request, user_id):
-    # input(user_id) is unicode
-    try:
-        user_id = int(user_id)
-    except ValueError:
-        return HttpResponseBadRequest('user_id must be an integer value.')
     user = get_object_or_404(get_user_model(), pk=user_id)
     return login_user(request, user)
 


### PR DESCRIPTION
I'm not sure what casting the `user_id` as an int is meant to accomplish in views.py, but on one of my projects the `user_id` is not always an integer and I noticed I was unable to hijack these users. 

Removing lines 16-20 fixes my issue and doesn't appear to have adverse effects. It would also address these issues https://github.com/arteria/django-hijack/issues/183 and https://github.com/arteria/django-hijack/issues/196.