### PR TITLE
Add semi-automatic release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,21 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  PyPI:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v2
+      - name: Install Python dependencies
+        run: python -m pip install --upgrade pip setuptools wheel twine
+      - name: Build dist packages
+        run: python setup.py sdist bdist_wheel
+      - name: Upload packages
+        run: python -m twine upload dist/*
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}


### PR DESCRIPTION
### ToDo:
- [ ] Set GitHub secret `TWINE_PASSWORD` with a valid API token, see also https://pypi.org/help/#apitoken

### Release Workflow

To create a new release a user would simply create a new GitHub release. This can be done by any repo member with write access.

### Future work

This workflow could be further enhanced using `setuptools-scm`, to derive the PyPi version number from Git tags and commits.