### PR TITLE
Use matrix for lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,45 +8,28 @@ on:
 
 jobs:
 
-  bandit:
+  lint:
+    strategy:
+      fail-fast: false
+      matrix:
+        lint-command: 
+          - "bandit -r hijack -x hijack/tests"
+          - "black --check --diff ."
+          - "flake8 ."
+          - "isort --check-only --diff ."
+          - "pydocstyle ."
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v2
       - uses: actions/checkout@v2
-      - run: python -m pip install `cat requirements.txt | grep bandit`
-      - run: bandit -r hijack -x hijack/tests
-
-  black:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/setup-python@v1
-      - uses: actions/checkout@v2
-      - run: python -m pip install `cat requirements.txt | grep black`
-      - run: black --check --diff .
-
-  flake8:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/setup-python@v1
-      - uses: actions/checkout@v2
-      - run: python -m pip install `cat requirements.txt | grep flake8`
-      - run: flake8 .
-
-  isort:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/setup-python@v1
-      - uses: actions/checkout@v2
-      - run: python -m pip install `cat requirements.txt | grep isort`
-      - run: isort --check-only --diff .
-
-  pydocstyle:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/setup-python@v1
-      - uses: actions/checkout@v2
-      - run: python -m pip install `cat requirements.txt | grep pydocstyle`
-      - run: pydocstyle .
+      - uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - run: python -m pip install -r requirements.txt
+      - run: ${{ matrix.lint-command }}
 
   dist:
     runs-on: ubuntu-latest
@@ -60,12 +43,8 @@ jobs:
   pytest:
     runs-on: ubuntu-latest
     needs:
-      - bandit
-      - black
       - dist
-      - flake8
-      - isort
-      - pydocstyle
+      - lint
     strategy:
       matrix:
         python-version:


### PR DESCRIPTION
Added a matrix for lint action
Added caching for packages from requirements.txt


This way the code looks much more compact and we don't repeat the same actions.
I also got rid of `cat` from requirements.txt and install all dependencies at once. No need to worry as they are now cached.