### PR TITLE
Docs: fix load static

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -45,7 +45,7 @@ To set up the notification bar, add the following lines to your `base.html` or t
 
 ```html
 <!-- At the top -->
-{% load staticfiles %}
+{% load static %}
 {% load hijack_tags %}
 
 ...


### PR DESCRIPTION
`{% load staticfiles %}` has been deprecated since Django 1.10.
Changed to current `{% load static %}`.