### PR TITLE
Fix notification button appearance in Django admin

### DIFF
--- a/hijack/static/hijack/hijack.scss
+++ b/hijack/static/hijack/hijack.scss
@@ -52,7 +52,9 @@
   }
 
   &-button {
+    appearance: none;
     border: none;
+    background-color: transparent;
     font-weight: 500;
     text-transform: uppercase;
     padding: 0.5em;


### PR DESCRIPTION
In Django admin the button has a background color, which I didn't notice before, see here:
<img width="271" alt="Screenshot 2021-03-27 at 10 26 41" src="https://user-images.githubusercontent.com/1772890/112716537-44ee7580-8ee7-11eb-9a68-7c6359a9599c.png">

I removed it, so the buttons look flat as they should.
