### PR TITLE
Add django-compat as a dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ include_package_data = True
 packages = hijack
 install_requires =
     django>=2.2
+    django-compat
 setup_requires =
     setuptools_scm
     pytest-runner


### PR DESCRIPTION
Hi,

I mentioned this briefly in #231, and thought I'd raise it one more time in case it's helpful:

Would it make sense to specify that `django-compat` as a required dependency in setup.py, so it's installed *with* django-hijack?

![image](https://user-images.githubusercontent.com/25310870/123771954-c4ffef00-d8cb-11eb-94b9-c122c035534c.png)

Without the entry in `setup.py`, users have to find and install the package when trying to follow the installation docs 🙂 