### PR TITLE
Fix block overlay

### DIFF
--- a/hijack/static/hijack/hijack.scss
+++ b/hijack/static/hijack/hijack.scss
@@ -1,11 +1,9 @@
 .djhj {
   position: fixed;
   bottom: 0;
-  width: 100%;
-  height: auto;
+  left: 50%;
+  transform: translateX(-50%);
   z-index: 300;
-  display: flex;
-  justify-content: center;
 
   &-notification {
     display: flex;


### PR DESCRIPTION
The block overlapped and prevented clicking on elements
![image](https://user-images.githubusercontent.com/13697400/128019971-dae8a907-8b1b-4fb7-a72c-bbbce3e2c908.png)
