### PR TITLE
Add correct german translations for DjangoAdmin integration

### DIFF
--- a/hijack/locale/de/LC_MESSAGES/django.po
+++ b/hijack/locale/de/LC_MESSAGES/django.po
@@ -24,7 +24,7 @@ msgstr "übernehmen"
 #: contrib/admin/templates/hijack/contrib/admin/button.html:11
 #, python-format
 msgid "Hijack %(username)s"
-msgstr "Als %(username)s anmelden"
+msgstr "%(username)s übernehmen"
 
 #: templates/hijack/notification.html:7
 #, python-format

--- a/hijack/locale/de/LC_MESSAGES/django.po
+++ b/hijack/locale/de/LC_MESSAGES/django.po
@@ -19,7 +19,7 @@ msgstr "Nutzer übernehmen"
 
 #: contrib/admin/templates/hijack/contrib/admin/button.html:8
 msgid "hijack"
-msgstr "Als Nutzer anmelden"
+msgstr "übernehmen"
 
 #: contrib/admin/templates/hijack/contrib/admin/button.html:11
 #, python-format

--- a/hijack/locale/de/LC_MESSAGES/django.po
+++ b/hijack/locale/de/LC_MESSAGES/django.po
@@ -15,16 +15,16 @@ msgstr ""
 
 #: contrib/admin/admin.py:35
 msgid "hijack user"
-msgstr "Nutzer entführen"
+msgstr "Nutzer übernehmen"
 
 #: contrib/admin/templates/hijack/contrib/admin/button.html:8
 msgid "hijack"
-msgstr "entführen"
+msgstr "Als Nutzer anmelden"
 
 #: contrib/admin/templates/hijack/contrib/admin/button.html:11
 #, python-format
 msgid "Hijack %(username)s"
-msgstr "%(username)s entführen"
+msgstr "Als %(username)s anmelden"
 
 #: templates/hijack/notification.html:7
 #, python-format
@@ -37,4 +37,4 @@ msgstr "Ausblenden"
 
 #: templates/hijack/notification.html:18
 msgid "release"
-msgstr "freigeben"
+msgstr "Übernahme beenden"

--- a/hijack/locale/de/LC_MESSAGES/django.po
+++ b/hijack/locale/de/LC_MESSAGES/django.po
@@ -33,7 +33,7 @@ msgstr "Sie arbeiten mit dem Account von <em>%(user)s</em>."
 
 #: templates/hijack/notification.html:15
 msgid "hide"
-msgstr "Ausblenden"
+msgstr "ausblenden"
 
 #: templates/hijack/notification.html:18
 msgid "release"

--- a/hijack/locale/de/LC_MESSAGES/django.po
+++ b/hijack/locale/de/LC_MESSAGES/django.po
@@ -37,4 +37,4 @@ msgstr "ausblenden"
 
 #: templates/hijack/notification.html:18
 msgid "release"
-msgstr "Übernahme beenden"
+msgstr "beenden"


### PR DESCRIPTION
As explained in issue [issue 335](https://github.com/django-hijack/django-hijack/issues/335) this are the corrected translation.
I used mainly the translation of the former django-hijack-admin package to come up with the suggested changes.