### PR TITLE
tests: fix issue where we were modifying the global settings inside `test_process_response__insert_before__is_none`

### DIFF
--- a/hijack/tests/test_middleware.py
+++ b/hijack/tests/test_middleware.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 from django.contrib.auth import get_user_model
 from django.http import HttpResponse, JsonResponse
 
-from hijack import conf, middleware
+from hijack import middleware
 
 
 class TestHijackRemoteUserMiddleware:
@@ -83,8 +83,8 @@ class TestHijackRemoteUserMiddleware:
         assert response["Content-Length"] == "21"
         assert response.content == b"<body>HIJACKED</body>"
 
-    def test_process_response__insert_before__is_none(self, rf, monkeypatch):
-        conf.settings.HIJACK_INSERT_BEFORE = None
+    def test_process_response__insert_before__is_none(self, rf, settings, monkeypatch):
+        settings.HIJACK_INSERT_BEFORE = None
         request = rf.get("/")
         request.user = get_user_model()
         request.user.is_hijacked = True


### PR DESCRIPTION
Noticed in the last release that the test added in #348 unintentionally modifies the global `settings` object 

![2021-10-18_11-05](https://user-images.githubusercontent.com/1423728/137784752-6b1b2768-385f-4c88-907b-522b1a6dad73.png)

Instead [use pytest-django's `setting` fixture](https://pytest-django.readthedocs.io/en/latest/helpers.html#settings) so that the test doesn't leak state to other tests.

Might want to consider [`pytest-randomly`](https://github.com/pytest-dev/pytest-randomly) which might flag up other places where tests are unintentionally modifying the state for other tests.