### PR TITLE
Fix #369 -- Do not allow inactive users to be hijacked

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -45,12 +45,12 @@ a boolean value. Example:
 ```python
 # mysite/permissions.py
 
-def hijack_superusers_only(*, hijacker=None, hijacked=None):
+def hijack_superusers_only(*, hijacker, hijacked):
     """Only superusers may hijack other users."""
     return hijacked.is_active and hijacker.is_superuser
 
 
-def hijack_staff_other_staff(*, hijacker=None, hijacked=None):
+def hijack_staff_other_staff(*, hijacker, hijacked):
     """Staff members may hijack other staff and regular users, but not superusers."""
     if not hijacked.is_active:
         return False

--- a/hijack/permissions.py
+++ b/hijack/permissions.py
@@ -1,9 +1,9 @@
-def superusers_only(*, hijacker=None, hijacked=None):
+def superusers_only(*, hijacker, hijacked):
     """Superusers may hijack any other user."""
     return hijacked.is_active and hijacker.is_superuser
 
 
-def superusers_and_staff(*, hijacker=None, hijacked=None):
+def superusers_and_staff(*, hijacker, hijacked):
     """
     Superusers and staff members may hijack other users.
 

--- a/hijack/permissions.py
+++ b/hijack/permissions.py
@@ -1,6 +1,6 @@
 def superusers_only(*, hijacker=None, hijacked=None):
     """Superusers may hijack any other user."""
-    return hijacker.is_superuser
+    return hijacked.is_active and hijacker.is_superuser
 
 
 def superusers_and_staff(*, hijacker=None, hijacked=None):
@@ -10,6 +10,9 @@ def superusers_and_staff(*, hijacker=None, hijacked=None):
     A superuser may hijack any other user.
     A staff member may hijack any user, except another staff member or superuser.
     """
+    if not hijacked.is_active:
+        return False
+
     if hijacker.is_superuser:
         return True
 

--- a/hijack/tests/test_permissions.py
+++ b/hijack/tests/test_permissions.py
@@ -6,6 +6,7 @@ from hijack import permissions
 superuser = get_user_model()(is_superuser=True)
 staff_member = get_user_model()(is_staff=True)
 regular_user = get_user_model()()
+inactive_user = get_user_model()(is_active=False)
 
 
 @pytest.mark.parametrize(
@@ -14,12 +15,15 @@ regular_user = get_user_model()()
         (superuser, superuser, True),
         (superuser, staff_member, True),
         (superuser, regular_user, True),
+        (superuser, inactive_user, False),
         (staff_member, regular_user, False),
         (staff_member, staff_member, False),
         (staff_member, superuser, False),
+        (staff_member, inactive_user, False),
         (regular_user, superuser, False),
         (regular_user, staff_member, False),
         (regular_user, regular_user, False),
+        (regular_user, inactive_user, False),
     ],
 )
 def test_superusers_only(hijacker, hijacked, has_perm):
@@ -32,12 +36,15 @@ def test_superusers_only(hijacker, hijacked, has_perm):
         (superuser, superuser, True),
         (superuser, staff_member, True),
         (superuser, regular_user, True),
+        (superuser, inactive_user, False),
         (staff_member, regular_user, True),
         (staff_member, staff_member, False),
         (staff_member, superuser, False),
+        (staff_member, inactive_user, False),
         (regular_user, superuser, False),
         (regular_user, staff_member, False),
         (regular_user, regular_user, False),
+        (regular_user, inactive_user, False),
     ],
 )
 def test_superusers_and_staff(hijacker, hijacked, has_perm):


### PR DESCRIPTION
Hijacking inactive users (i.e. users with `is_active=False`) is not allowed to prevent
dead locks, since an inactive user cannot be released.