### PR TITLE
Do not touch empty sessions to avoid vary on cookie header

### DIFF
--- a/hijack/middleware.py
+++ b/hijack/middleware.py
@@ -15,6 +15,9 @@ class HijackUserMiddleware(MiddlewareMixin):
 
     def process_request(self, request):
         """Set `is_hijacked` and override REMOTE_USER header."""
+        if request.session.is_empty():
+            # do not touch empty sessions to avoid unnecessary vary on cookie header
+            return
         request.user.is_hijacked = bool(request.session.get("hijack_history", []))
         if "REMOTE_USER" in request.META and request.user.is_hijacked:
             request.META["REMOTE_USER"] = request.user.get_username()


### PR DESCRIPTION
Django's session middleware sets the vary on cookie header if
the session has been accessed by the request or any other
middleware. Therefore, we need to avoid loading the session
of the session is empty and there is not user, nor any hijacked
user for that matter.
