### PR TITLE
Ignore hijacking logic in response processing in case of empty session

### DIFF
--- a/hijack/middleware.py
+++ b/hijack/middleware.py
@@ -24,6 +24,10 @@ class HijackUserMiddleware(MiddlewareMixin):
 
     def process_response(self, request, response):
         """Render hijack notification and inject into HTML response."""
+        if request.session.is_empty():
+            # do not touch empty sessions to avoid unnecessary vary on cookie header
+            return response
+
         insert_before = settings.HIJACK_INSERT_BEFORE
         if not getattr(request.user, "is_hijacked", False) or insert_before is None:
             return response

--- a/hijack/tests/test_middleware.py
+++ b/hijack/tests/test_middleware.py
@@ -51,10 +51,19 @@ class TestHijackRemoteUserMiddleware:
         assert not bob.is_hijacked
         assert request.META["REMOTE_USER"] == "eve"
 
+    def test_process_response__session_not_accessed(self, rf, monkeypatch, bob):
+        request = rf.get("/")
+        request.user = bob
+        request.session = SessionStore()
+        response = HttpResponse("")
+        assert self.middleware.process_response(request, response) is response
+        assert not request.session.accessed
+
     def test_process_response__html(self, rf, monkeypatch):
         request = rf.get("/")
         request.user = get_user_model()
         request.user.is_hijacked = True
+        request.session = SessionStore("some_session_key")
         request.META["CSRF_COOKIE"] = "123456"
         render_to_string = MagicMock()
         response = HttpResponse("")
@@ -69,6 +78,7 @@ class TestHijackRemoteUserMiddleware:
         request = rf.get("/")
         request.user = get_user_model()
         request.user.is_hijacked = True
+        request.session = SessionStore("some_session_key")
         render_to_string = MagicMock()
         response = JsonResponse({})
         monkeypatch.setattr("hijack.middleware.render_to_string", render_to_string)
@@ -79,6 +89,7 @@ class TestHijackRemoteUserMiddleware:
         request = rf.get("/")
         request.user = get_user_model()
         request.user.is_hijacked = True
+        request.session = SessionStore("some_session_key")
         request.META["CSRF_COOKIE"] = "123456"
         render_to_string = MagicMock()
         render_to_string.return_value = "HIJACKED"
@@ -98,6 +109,7 @@ class TestHijackRemoteUserMiddleware:
         request = rf.get("/")
         request.user = get_user_model()
         request.user.is_hijacked = True
+        request.session = SessionStore("some_session_key")
         request.META["CSRF_COOKIE"] = "123456"
         render_to_string = MagicMock()
         monkeypatch.setattr("hijack.middleware.render_to_string", render_to_string)


### PR DESCRIPTION
Follow up on #407 - `process_response` is affected in a similar way.
In order to decide on notification rendering, library checks `request.user.is_hijacked`, which accesses the session. We can skip that part when the session is empty.
