### PR TITLE
Update button.html

### DIFF
--- a/hijack/contrib/admin/templates/hijack/contrib/admin/button.html
+++ b/hijack/contrib/admin/templates/hijack/contrib/admin/button.html
@@ -1,7 +1,7 @@
-{% load i18n hijack %}
+{% load i18n l10n hijack %}
 
 {% if request.user|can_hijack:another_user %}
-  <button type="button" class="button" data-hijack-user="{{ another_user.pk }}"
+  <button type="button" class="button" data-hijack-user="{{ another_user.pk|unlocalize }}"
           data-hijack-next="{{ next }}" data-hijack-url="{% url 'hijack:acquire' %}">
     {% if is_user_admin %}
       {% trans 'hijack'|upper %}


### PR DESCRIPTION
Fixes an issue where a user's primary key is > 999 and USE_L10N is True and USE_THOUSAND_SEPARATOR is True.

In our setup once we had more than 1000 users with these settings enabled, the button's `data-hijack-user` attribute had a comma in it, which caused a ValueError "Field 'id' expected a number but got '1,151'".