### PR TITLE
Resolve #504 -- Use a RequestContext to render templates

### DIFF
--- a/hijack/contrib/admin/admin.py
+++ b/hijack/contrib/admin/admin.py
@@ -52,6 +52,7 @@ class HijackUserAdminMixin:
                 "is_user_admin": self.model == type(user),
                 "next": self.get_hijack_success_url(request, obj),
             },
+            request=request,
         )
 
     def get_changelist_instance(self, request):

--- a/hijack/middleware.py
+++ b/hijack/middleware.py
@@ -44,7 +44,8 @@ class HijackUserMiddleware(MiddlewareMixin):
 
         rendered = render_to_string(
             "hijack/notification.html",
-            {"request": request, "csrf_token": request.META["CSRF_COOKIE"]},
+            {"request": request},
+            request=request,
         )
 
         # Insert the toolbar in the response.

--- a/hijack/tests/test_middleware.py
+++ b/hijack/tests/test_middleware.py
@@ -71,7 +71,8 @@ class TestHijackRemoteUserMiddleware:
         assert self.middleware.process_response(request, response) is response
         render_to_string.assert_called_once_with(
             "hijack/notification.html",
-            {"request": request, "csrf_token": "123456"},
+            {"request": request},
+            request=request,
         )
 
     def test_process_response__non_html(self, rf, monkeypatch):
@@ -99,7 +100,8 @@ class TestHijackRemoteUserMiddleware:
         assert self.middleware.process_response(request, response) is response
         render_to_string.assert_called_once_with(
             "hijack/notification.html",
-            {"request": request, "csrf_token": "123456"},
+            {"request": request},
+            request=request,
         )
         assert response["Content-Length"] == "21"
         assert response.content == b"<body>HIJACKED</body>"


### PR DESCRIPTION
Render both the admin button and the middleware notification template
using a `RequestContext` instead of a `RenderContext`. This will
cause the CSRF token to be injected automatically into the context
for the notitication. Futhermore, users are able to inject their
own context, via context processors, to futher customize their
templates.
