### PR TITLE
Fix setup script and CI

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ long_description = file: README.md
 long_description_content_type = text/markdown
 url = https://github.com/django-hijack/django-hijack
 license = MIT
-license_file = LICENSE
+license_files = LICENSE
 platforms =
     OS Independent
 keywords =


### PR DESCRIPTION
Setuptools doesn't create empty folders anymore. Therefore, we need to manually create the folders before compiling the MO files using gettext.