### PR TITLE
Prune tests from the package distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 prune .github
+prune hijack/tests
 exclude .gitignore
 exclude requirements.txt
 include hijack/locale/*/LC_MESSAGES/django.mo hijack/static/hijack/hijack.min.*


### PR DESCRIPTION
Greetings dear fellows,

I noticed that the package distribution contains tests, which I don't see the need of (tell me, if I am missing something).
This PR updates MANIFEST.in to prune tests folder.

Best,
Rust