### PR TITLE
Add official Django 5.0 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,7 @@ jobs:
           - "3.2"
           - "4.1"
           - "4.2"
+          - "5.0"
         exclude:
           - django-version: "3.2"
             python-version: "3.11"
@@ -105,6 +106,11 @@ jobs:
             python-version: "3.12"
           - django-version: "4.1"
             python-version: "3.12"
+          - django-version: "5.0"
+            python-version: "3.8"
+          - django-version: "5.0"
+            python-version: "3.9"
+            
     steps:
       - uses: actions/checkout@v4
       - run: sudo apt install -y gettext

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,5 +34,5 @@ python -m pip install -e '.[test]'
 Simply run:
 
 ```shell
-pytest
+py.test
 ```

--- a/hijack/tests/test_app/settings.py
+++ b/hijack/tests/test_app/settings.py
@@ -1,6 +1,7 @@
 """Settings that need to be set in order to run the tests."""
 import os
 
+import django
 from django.urls import reverse_lazy
 
 DEBUG = True
@@ -100,4 +101,5 @@ LOGOUT_REDIRECT_URL = reverse_lazy("bye-bye")
 
 AUTH_USER_MODEL = "test_app.CustomUser"
 
-SESSION_SERIALIZER = "django.contrib.sessions.serializers.PickleSerializer"
+if django.VERSION < (4, 0):
+    SESSION_SERIALIZER = "django.contrib.sessions.serializers.PickleSerializer"

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ classifiers =
     Framework :: Django :: 3.2
     Framework :: Django :: 4.1
     Framework :: Django :: 4.2
+    Framework :: Django :: 5.0
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.8


### PR DESCRIPTION
Built on top of #627, Add support for the new Django 5.0 version

- Added to the CI.
- Updated pypi classifiers

Awareness:
- The [PickleSerializer](https://docs.djangoproject.com/en/4.2/topics/http/sessions/#django.contrib.sessions.serializers.PickleSerializer) used in the tests is deprecated since Django 4.1 and is removed in Django5. But the Json alternative can't serialize datetimes with Django 3.2. Considering the remaining lifetime of Django 3.2 I let it use the old Serializer.

Thanks a lot for maintaining this lib!