### PR TITLE
Add official Python 3.12 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,10 +93,18 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
+          - "3.12"
         django-version:
           - "3.2"
           - "4.1"
           - "4.2"
+        exclude:
+          - django-version: "3.2"
+            python-version: "3.11"
+          - django-version: "3.2"
+            python-version: "3.12"
+          - django-version: "4.1"
+            python-version: "3.12"
     steps:
       - uses: actions/checkout@v4
       - run: sudo apt install -y gettext

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,5 +34,5 @@ python -m pip install -e '.[test]'
 Simply run:
 
 ```shell
-py.test
+pytest
 ```

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
 
 [options]
 include_package_data = True


### PR DESCRIPTION
Add Python 3.12 official support:

- Added to CI (I had to tweak the github action matrix according to the [Django supported versions](https://docs.djangoproject.com/en/4.2/faq/install/#what-python-version-can-i-use-with-django) documentation.
)
- Updated pypi classifiers
- Updated "pytest" command in CONTRIBUTING.md