### PR TITLE
Ref #613  -- Handle unauthenticated users in hijack views

### DIFF
--- a/hijack/views.py
+++ b/hijack/views.py
@@ -69,8 +69,8 @@ class LockUserTableMixin:
 
 
 class AcquireUserView(
-    LockUserTableMixin,
     LoginRequiredMixin,
+    LockUserTableMixin,
     UserPassesTestMixin,
     SuccessUrlMixin,
     SingleObjectMixin,
@@ -117,7 +117,11 @@ class AcquireUserView(
 
 
 class ReleaseUserView(
-    LockUserTableMixin, LoginRequiredMixin, UserPassesTestMixin, SuccessUrlMixin, View
+    LoginRequiredMixin,
+    LockUserTableMixin,
+    UserPassesTestMixin,
+    SuccessUrlMixin,
+    View,
 ):
     raise_exception = True
 


### PR DESCRIPTION
If the user is not authenticated, `LockUserTableMixin.dispatch` raises `User.DoesNotExist`. This started happening after https://github.com/django-hijack/django-hijack/commit/a36fbb8fa71206ad01d330e9f34bb321d5340f82:

https://github.com/django-hijack/django-hijack/blob/a36fbb8fa71206ad01d330e9f34bb321d5340f82/hijack/views.py#L67

To address it, I changed the parent classes order so `LoginRequiredMixin` does its job first.