### PR TITLE
Drop official Django 4.1 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,6 @@ jobs:
           - "3.12"
         django-version:
           - "3.2"
-          - "4.1"
           - "4.2"
           - "5.0"
         exclude:
@@ -104,13 +103,11 @@ jobs:
             python-version: "3.11"
           - django-version: "3.2"
             python-version: "3.12"
-          - django-version: "4.1"
-            python-version: "3.12"
           - django-version: "5.0"
             python-version: "3.8"
           - django-version: "5.0"
             python-version: "3.9"
-            
+
     steps:
       - uses: actions/checkout@v4
       - run: sudo apt install -y gettext

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,6 @@ classifiers =
     License :: OSI Approved :: MIT License
     Framework :: Django
     Framework :: Django :: 3.2
-    Framework :: Django :: 4.1
     Framework :: Django :: 4.2
     Framework :: Django :: 5.0
     Programming Language :: Python


### PR DESCRIPTION
Django 4.1 reached the end of life on December 1. 2023.