### PR TITLE
Ensure transaction.atomic is against the db with the User model.

### DIFF
--- a/hijack/tests/conftest.py
+++ b/hijack/tests/conftest.py
@@ -37,3 +37,7 @@ def eve_client(eve):
     client = Client()
     client.force_login(eve)
     return client
+
+@pytest.fixture()
+def other_db_router(settings):
+    settings.DATABASE_ROUTERS = ["hijack.tests.test_app.routers.TestAppRouter"]

--- a/hijack/tests/conftest.py
+++ b/hijack/tests/conftest.py
@@ -38,6 +38,7 @@ def eve_client(eve):
     client.force_login(eve)
     return client
 
+
 @pytest.fixture()
 def other_db_router(settings):
     settings.DATABASE_ROUTERS = ["hijack.tests.test_app.routers.TestAppRouter"]

--- a/hijack/tests/test_app/routers.py
+++ b/hijack/tests/test_app/routers.py
@@ -1,0 +1,15 @@
+class TestAppRouter:
+    def db_for_read(self, model, **hints):
+        return "other"
+
+    def db_for_write(self, model, **hints):
+        return "other"
+
+    def allow_relation(self, *args, **kwargs):
+        return True
+
+    def allow_syncdb(self, *args, **kwargs):
+        return True
+
+    def allow_migrate(self, *args, **kwargs):
+        return True

--- a/hijack/tests/test_app/settings.py
+++ b/hijack/tests/test_app/settings.py
@@ -14,6 +14,10 @@ DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.sqlite3",
         "NAME": ":memory:",
+    },
+    "other": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": ":memory:",
     }
 }
 

--- a/hijack/tests/test_app/settings.py
+++ b/hijack/tests/test_app/settings.py
@@ -18,7 +18,7 @@ DATABASES = {
     "other": {
         "ENGINE": "django.db.backends.sqlite3",
         "NAME": ":memory:",
-    }
+    },
 }
 
 

--- a/hijack/views.py
+++ b/hijack/views.py
@@ -2,7 +2,7 @@ from contextlib import contextmanager
 
 from django.contrib.auth import BACKEND_SESSION_KEY, get_user_model, load_backend, login
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
-from django.db import transaction
+from django.db import transaction, ConnectionRouter
 from django.http import HttpResponseBadRequest, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, resolve_url
 from django.utils.decorators import method_decorator
@@ -56,11 +56,12 @@ class SuccessUrlMixin:
 
 
 class LockUserTableMixin:
-    @transaction.atomic()
     def dispatch(self, request, *args, **kwargs):
+        write_db = ConnectionRouter().db_for_write(get_user_model())
         # Lock user row to avoid race conditions
-        get_user_model()._base_manager.select_for_update().get(pk=request.user.pk)
-        return super().dispatch(request, *args, **kwargs)
+        with transaction.atomic(using=write_db):
+            get_user_model()._base_manager.select_for_update().get(pk=request.user.pk)
+            return super().dispatch(request, *args, **kwargs)
 
 
 class AcquireUserView(

--- a/hijack/views.py
+++ b/hijack/views.py
@@ -2,7 +2,7 @@ from contextlib import contextmanager
 
 from django.contrib.auth import BACKEND_SESSION_KEY, get_user_model, load_backend, login
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
-from django.db import transaction, ConnectionRouter
+from django.db import ConnectionRouter, transaction
 from django.http import HttpResponseBadRequest, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, resolve_url
 from django.utils.decorators import method_decorator


### PR DESCRIPTION
Hello,

The `transaction.atomic` call to lock the User table currently always happens against the default DB. This is because `transaction.atomic` has no knowledge of which databases will be queried in a multi database scenario (since the queried database is determined dynamically by the database router being used).

This PR updates the flow to fetch the database that is used for writing to the User model, and ensures a lock is placed against that specific database.

Happy to get feedback on the fix and the test. Thanks!