### PR TITLE
Add optional request argument to permission check function

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -47,7 +47,45 @@ urlpatterns = [
 
 ### Hijacking another user
 
+#### Using template tag
+
 The following example shows how to integrate a hijack button into your template.
+
+
+```html
+{% load hijack %}
+<html>
+<body>
+{# … #}
+{% can_hijack_tag hijacker=request.user hijacked=another_user as can_hijack_user %}
+{% if can_hijack_user %}
+<form action="{% url 'hijack:acquire' %}" method="POST">
+  {% csrf_token %}
+  <input type="hidden" name="user_pk" value="{{ another_user.pk }}">
+  <button type="submit">hijack {{ another_user }}</button>
+  <input type="hidden" name="next" value="{{ request.path }}">
+</form>
+{% endif %}
+{# … #}
+</body>
+</html>
+```
+
+A form is used to perform a POST including a [CSRF][CSRF]-token for security reasons.
+The field `user_pk` is mandatory and the value must be set to the target users' primary
+key. The optional field `next` determines where a user is forwarded after a successful hijack.
+If not provided, users are forwarded to the [LOGIN_REDIRECT_URL][LOGIN_REDIRECT_URL].
+
+Do not forget to load the `hijack` template tags to use the `can_hijack_tag` templatetag.
+The `can_hijack_tag` returns a boolean value, it requires both user hijacker abd hijacked one.
+
+[CSRF]: https://docs.djangoproject.com/en/stable/ref/csrf/
+[LOGIN_REDIRECT_URL]: https://docs.djangoproject.com/en/stable/ref/settings/#login-redirect-url
+
+
+#### Using template filter
+
+The same can be achieved using the `can_hijack_tag` template filter.
 
 ```html
 {% load hijack %}
@@ -67,18 +105,13 @@ The following example shows how to integrate a hijack button into your template.
 </html>
 ```
 
-A form is used to perform a POST including a [CSRF][CSRF]-token for security reasons.
-The field `user_pk` is mandatory and the value must be set to the target users' primary
-key. The optional field `next` determines where a user is forwarded after a successful hijack. 
-If not provided, users are forwarded to the [LOGIN_REDIRECT_URL][LOGIN_REDIRECT_URL].
-
 Do not forget to load the `hijack` template tags to use the `can_hijack` filter.
 The `can_hijack` returns a boolean value, the first argument should be user hijacker,
 the second value should be the hijacked.
 
-[CSRF]: https://docs.djangoproject.com/en/stable/ref/csrf/
-[LOGIN_REDIRECT_URL]: https://docs.djangoproject.com/en/stable/ref/settings/#login-redirect-url
-
+NOTE:
+When using `can_hijack` filter you **cannot** use a function requiring `request`
+argument in `HIJACK_PERMISSION_CHECK`; use `can_hijack_tag` templatetag instead.
 
 ### Django admin integration
 

--- a/hijack/contrib/admin/templates/hijack/contrib/admin/button.html
+++ b/hijack/contrib/admin/templates/hijack/contrib/admin/button.html
@@ -1,6 +1,7 @@
 {% load i18n l10n hijack %}
 
-{% if request.user|can_hijack:another_user %}
+{% can_hijack_tag hijacker=request.user hijacked=another_user as can_hijack_user %}
+{% if can_hijack_user %}
   <button type="button" class="button" data-hijack-user="{{ another_user.pk|unlocalize }}"
           data-hijack-next="{{ next }}" data-hijack-url="{% url 'hijack:acquire' %}">
     {% if is_user_admin %}

--- a/hijack/permissions.py
+++ b/hijack/permissions.py
@@ -1,3 +1,10 @@
+import inspect
+
+from jinja2.utils import import_string
+
+from hijack.conf import settings
+
+
 def superusers_only(*, hijacker, hijacked):
     """Superusers may hijack any other user."""
     if not hijacked:
@@ -19,3 +26,13 @@ def superusers_and_staff(*, hijacker, hijacked):
         return True
 
     return hijacker.is_staff and not (hijacked.is_staff or hijacked.is_superuser)
+
+
+def can_hijack_user(hijacker, hijacked, request):
+    """Test if the currently authenticated user can hijack another user."""
+    func = import_string(settings.HIJACK_PERMISSION_CHECK)
+    kwargs = dict(hijacker=hijacker, hijacked=hijacked)
+    if "request" in inspect.signature(func).parameters:
+        kwargs["request"] = request
+
+    return func(**kwargs)

--- a/hijack/templatetags/hijack.py
+++ b/hijack/templatetags/hijack.py
@@ -2,11 +2,12 @@ from django import template
 from django.utils.module_loading import import_string
 
 from hijack.conf import settings
+from hijack.permissions import can_hijack_user
 
 register = template.Library()
 
 
-@register.filter
+@register.filter()
 def can_hijack(hijacker, hijacked):
     """
     Test if a user can hijack another user.
@@ -20,3 +21,18 @@ def can_hijack(hijacker, hijacked):
     """
     func = import_string(settings.HIJACK_PERMISSION_CHECK)
     return func(hijacker=hijacker, hijacked=hijacked)
+
+
+@register.simple_tag(takes_context=True)
+def can_hijack_tag(context, hijacker, hijacked):
+    """
+    Test if the currently authenticated user can hijack another user.
+
+    Usage:
+
+        {% can_hijack_tag hijacker=request.user hijacked=another_user as can_hijack_user %}
+        {% if can_hijack_user %}
+          {# The currently authenticated user can hijack the user "another_user". #}
+        {% endif %}
+    """
+    return can_hijack_user(hijacker, hijacked, context["request"])

--- a/hijack/tests/test_app/permissions.py
+++ b/hijack/tests/test_app/permissions.py
@@ -4,3 +4,11 @@ def allow_all(*, hijacker, hijacked):
 
 def deny_all(*, hijacker, hijacked):
     return False
+
+
+def require_request_required(*, hijacker, hijacked, request):
+    return True
+
+
+def require_request_optional(*, hijacker, hijacked, request=None):
+    return True

--- a/hijack/tests/test_app/templates/user_list_tag.html
+++ b/hijack/tests/test_app/templates/user_list_tag.html
@@ -1,0 +1,16 @@
+{% load hijack %}
+<html>
+<body>
+{% for another_user in object_list %}
+  {% can_hijack_tag hijacker=request.user hijacked=another_user as can_hijack_user %}
+  {% if can_hijack_user %}
+    <form action="{% url 'hijack:acquire' %}" method="POST">
+      {% csrf_token %}
+      <input type="hidden" name="user_pk" value="{{ another_user.pk }}">
+      <button type="submit">hijack {{ another_user }}</button>
+      <input type="hidden" name="next" value="{{ request.path }}">
+    </form>
+  {% endif %}
+{% endfor %}
+</body>
+</html>

--- a/hijack/tests/test_app/urls.py
+++ b/hijack/tests/test_app/urls.py
@@ -8,6 +8,7 @@ app_name = "test_app"
 urlpatterns = [
     path("hijack/", include("hijack.urls", namespace="hijack")),
     path("users/", views.UserListView.as_view(), name="user-list"),
+    path("users-with-tag/", views.UserListTagView.as_view(), name="user-list-tag"),
     path("accounts/profile/", views.UserDetailView.as_view(), name="user-detail"),
     path(
         "bye-bye/", TemplateView.as_view(template_name="bye_bye.html"), name="bye-bye"

--- a/hijack/tests/test_app/views.py
+++ b/hijack/tests/test_app/views.py
@@ -8,6 +8,11 @@ class UserListView(generic.ListView):
     template_name = "user_list.html"
 
 
+class UserListTagView(generic.ListView):
+    model = get_user_model()
+    template_name = "user_list_tag.html"
+
+
 class UserDetailView(generic.View):
     def get(self, request, *args, **kwargs):
         return JsonResponse({"username": request.user.username})

--- a/hijack/tests/test_templatetags.py
+++ b/hijack/tests/test_templatetags.py
@@ -1,12 +1,26 @@
+from unittest.mock import patch
+
+import pytest
 from django.urls import reverse
 
 from hijack.templatetags import hijack as templatetags
 
-from .test_app.permissions import allow_all, deny_all
+from .test_app.permissions import (
+    allow_all,
+    deny_all,
+    require_request_required,
+    require_request_optional,
+)
 
 
 def test_can_hijack__integration(admin_client):
     response = admin_client.get(reverse("user-list"))
+    assert response.status_code == 200
+    assert b'<button type="submit">hijack admin</button>' in response.content
+
+
+def test_can_hijack_tag__integration(admin_client):
+    response = admin_client.get(reverse("user-list-tag"))
     assert response.status_code == 200
     assert b'<button type="submit">hijack admin</button>' in response.content
 
@@ -19,3 +33,99 @@ def test_can_hijack__import_string(settings):
 
     settings.HIJACK_PERMISSION_CHECK = f"{deny_all.__module__}.{deny_all.__qualname__}"
     assert not templatetags.can_hijack(None, None)
+
+
+def test_can_hijack_tag__no_use_request(settings, rf):
+    """
+    request is not passed to the permission check function if not a kwarg of it.
+    """
+    request = rf.get("/")
+    settings.HIJACK_PERMISSION_CHECK = (
+        f"{allow_all.__module__}.{allow_all.__qualname__}"
+    )
+    with patch(
+        "hijack.tests.test_app.permissions.allow_all", autospec=True
+    ) as allow_all_func:
+        templatetags.can_hijack_tag({"request": request}, None, None)
+        allow_all_func.assert_called_once_with(hijacker=None, hijacked=None)
+
+
+def test_can_hijack_tag__use_request(settings, rf):
+    """
+    request is passed to the permission check function if it's a function kwarg.
+    """
+    request = rf.get("/")
+    settings.HIJACK_PERMISSION_CHECK = (
+        f"{require_request_required.__module__}.{require_request_required.__qualname__}"
+    )
+    with patch(
+        "hijack.tests.test_app.permissions.require_request_required", autospec=True
+    ) as require_request_func:
+        templatetags.can_hijack_tag({"request": request}, None, None)
+        require_request_func.assert_called_once_with(
+            hijacker=None, hijacked=None, request=request
+        )
+
+
+def test_can_hijack_tag__use_request_optional(settings, rf):
+    """
+    request is passed to the permission check function if it's a function kwarg.
+    """
+    request = rf.get("/")
+    settings.HIJACK_PERMISSION_CHECK = (
+        f"{require_request_optional.__module__}.{require_request_optional.__qualname__}"
+    )
+    with patch(
+        "hijack.tests.test_app.permissions.require_request_optional", autospec=True
+    ) as require_request_func:
+        templatetags.can_hijack_tag({"request": request}, None, None)
+        require_request_func.assert_called_once_with(
+            hijacker=None, hijacked=None, request=request
+        )
+
+
+def test_can_hijack_filter__no_use_request(settings):
+    """
+    request is not passed to the permission check function if not a kwarg of it.
+    """
+    settings.HIJACK_PERMISSION_CHECK = (
+        f"{allow_all.__module__}.{allow_all.__qualname__}"
+    )
+    with patch(
+        "hijack.tests.test_app.permissions.allow_all", autospec=True
+    ) as allow_all_func:
+        templatetags.can_hijack(None, None)
+        allow_all_func.assert_called_once_with(hijacker=None, hijacked=None)
+
+
+def test_can_hijack_filter__use_request(settings):
+    """
+    If request argument is required, calling the filter will result in an exception.
+
+    request object is not available in the template filter.
+    """
+    settings.HIJACK_PERMISSION_CHECK = (
+        f"{require_request_required.__module__}.{require_request_required.__qualname__}"
+    )
+    with patch(
+        "hijack.tests.test_app.permissions.require_request_required", autospec=True
+    ) as require_request_func:
+        with pytest.raises(TypeError):
+            templatetags.can_hijack(None, None)
+        require_request_func.assert_not_called()
+
+
+def test_can_hijack_filter__use_request_optional(settings):
+    """
+    When using the filter, the request is not passed to the permission check function.
+
+    If request argument is optional, the check is run without the request argument.
+    """
+    settings.HIJACK_PERMISSION_CHECK = (
+        f"{require_request_optional.__module__}.{require_request_optional.__qualname__}"
+    )
+    with patch(
+        "hijack.tests.test_app.permissions.require_request_optional", autospec=True
+    ) as require_request_func:
+        templatetags.can_hijack(None, None)
+        require_request_func.assert_called_once_with(hijacker=None, hijacked=None)

--- a/hijack/views.py
+++ b/hijack/views.py
@@ -7,12 +7,11 @@ from django.http import HttpResponseBadRequest, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, resolve_url
 from django.utils.decorators import method_decorator
 from django.utils.http import url_has_allowed_host_and_scheme
-from django.utils.module_loading import import_string
 from django.views import View
 from django.views.decorators.csrf import csrf_protect
 from django.views.generic.detail import SingleObjectMixin
 
-from hijack import signals
+from hijack import permissions, signals
 from hijack.conf import settings
 
 
@@ -75,8 +74,9 @@ class AcquireUserView(
     success_url = settings.LOGIN_REDIRECT_URL
 
     def test_func(self):
-        func = import_string(settings.HIJACK_PERMISSION_CHECK)
-        return func(hijacker=self.request.user, hijacked=self.get_object())
+        return permissions.can_hijack_user(
+            hijacker=self.request.user, hijacked=self.get_object(), request=self.request
+        )
 
     def get_object(self, queryset=None):
         return get_object_or_404(self.model, pk=self.request.POST["user_pk"])


### PR DESCRIPTION
The request object might be needed when the permissions check are not limited to attributes attached to the users, but may depend on attributes of the request object.

In order to be able to use this argument one must use the templatetag introduced in this PR.

The implemented behavior is completely backward compatible: existing templates and permission checking function will continue to work without any changes.

See https://github.com/django-hijack/django-hijack/discussions/649 for a discussion about the implementation of this feature.