### PR TITLE
Move redirection code to a seperate method for easier inheritance

### DIFF
--- a/hijack/views.py
+++ b/hijack/views.py
@@ -37,6 +37,9 @@ class SuccessUrlMixin:
 
     success_url = "/"
 
+    def redirect(self):
+        return HttpResponseRedirect(self.get_success_url())
+
     def get_success_url(self):
         url = self.get_redirect_url()
         return url or resolve_url(self.success_url or "/")
@@ -108,7 +111,8 @@ class AcquireUserView(
             hijacker=hijacker,
             hijacked=hijacked,
         )
-        return HttpResponseRedirect(self.get_success_url())
+
+        return self.redirect()
 
 
 class ReleaseUserView(
@@ -144,4 +148,5 @@ class ReleaseUserView(
             hijacker=hijacker,
             hijacked=hijacked,
         )
-        return HttpResponseRedirect(self.get_success_url())
+
+        return self.redirect()


### PR DESCRIPTION
Hijack uses POST method and CSRF tokens for security purposes, as it should.

This makes it difficult to embed hijack links into existing admin templates (in my case Django Guardian object permissions template), because the user id is shown inside a form element, and HTML5 prohibits nesting form elements.

Linking to an outside form does not work either, because there are multiple users (and forms).

One way to overcome this limitation is to use HTMX to make the POST hijack request. But if we want HTMX to redirect, we need to add HX-Redirect header to the response.

To avoid implementing the whole post method when inheriting AcquireUserView, I made the redirect a seperate function that can be overridden.

Then you can do something like this (not tested):

```
class HijackAcquire(AcquireUserView):
    def redirect(self):
        response = HttpResponse('{"status": "ok"}')
        response['HX-Redirect'] = self.get_success_url()
        response['Access-Control-Expose-Headers'] = 'HX-Redirect'
        return response
```

```
{% for user in users %}
<button hx-post="{% url 'accounts:hijack-acquire' %}" hx-vals='{"user_pk": "{{ user.id | escapejs }}"}'>{{ user }}</button>
{% endfor %}
```

Of course you need to add the CSRF token to the request, for example in your base template:

````
<body hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
...
</body>
```