### PR TITLE
Fix Czech translation for "impersonate"

### DIFF
--- a/hijack/locale/cs/LC_MESSAGES/django.po
+++ b/hijack/locale/cs/LC_MESSAGES/django.po
@@ -25,7 +25,7 @@ msgstr "vydávat se za"
 #: contrib/admin/templates/hijack/contrib/admin/button.html:9
 #, python-format
 msgid "impersonate %(username)s"
-msgstr "uvolnit %(username)s"
+msgstr "vydávat se za %(username)s"
 
 #: templates/hijack/notification.html:8
 #, python-format


### PR DESCRIPTION
The previous translation was like "Release" - as you can see, my is the same as for the other `impersonate`'s