### PR TITLE
[feat] Add configuration to ignore redirecting to next url

### DIFF
--- a/hijack/conf.py
+++ b/hijack/conf.py
@@ -6,6 +6,7 @@ __all__ = ["settings"]
 class LazySettings:
     HIJACK_PERMISSION_CHECK = "hijack.permissions.superusers_only"
     HIJACK_INSERT_BEFORE = "</body>"
+    HIJACK_IGNORE_NEXT_URL = False
 
     def __getattribute__(self, name):
         try:

--- a/hijack/views.py
+++ b/hijack/views.py
@@ -38,8 +38,11 @@ class SuccessUrlMixin:
     success_url = "/"
 
     def get_success_url(self):
+        default_url = resolve_url(self.success_url or "/")
+        if settings.HIJACK_IGNORE_NEXT_URL:
+            return default_url
         url = self.get_redirect_url()
-        return url or resolve_url(self.success_url or "/")
+        return url or default_url
 
     def get_redirect_url(self):
         """Return the user-originating redirect URL if it's safe."""

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -10,7 +10,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.sessions.models import Session
 from django.db import connections
 from django.shortcuts import resolve_url
-from django.test import Client
+from django.test import Client, override_settings
 from django.test.utils import CaptureQueriesContext
 from django.urls import reverse_lazy
 from django.utils import timezone
@@ -45,6 +45,15 @@ class TestSuccessUrlMixin:
         get_redirect_url.return_value = ""
         view.get_redirect_url = get_redirect_url
         assert view.get_success_url() == "/bye-bye/"
+
+    @override_settings(HIJACK_IGNORE_NEXT_URL=True)
+    def test_get_success_url__ignore_next_url(self):
+        view = views.SuccessUrlMixin()
+        view.success_url = "/forced_redirect_url/"
+        get_redirect_url = MagicMock()
+        get_redirect_url.return_value = "/next_url/"
+        view.get_redirect_url = get_redirect_url
+        assert view.get_success_url() == "/forced_redirect_url/"
 
 
 class TestAcquireUserView:


### PR DESCRIPTION
Fixes #320 

Added new settings `HIJACK_IGNORE_NEXT_URL` to control the behavior of redirection. 

It defaults to `False` to maintain backward compatibility.

When `HIJACK_IGNORE_NEXT_URL` is set to `True`, both `AcquireUserView` and `ReleaseUserView` will always redirect to their predefined `success_url`, regardless of whether a `next` URL is provided by the template or not.

