### PR TITLE
Avoid request context for admin hijack buttons

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -147,20 +147,27 @@ You can override the hijack button that renders in the admin.
 Create a template called hijack/contrib/admin/button.html in your template folder.
 You can use the default template as a cheat-sheet.
 
-```
-{% load i18n l10n hijack %}
+```django
+{% load i18n l10n %}
 
-{% if request.user|can_hijack:another_user %}
+{% if can_hijack %}
   <button type="button" class="button" data-hijack-user="{{ another_user.pk|unlocalize }}"
-          data-hijack-next="{{ next }}" data-hijack-url="{% url 'hijack:acquire' %}">
+          data-hijack-next="{{ next }}" data-hijack-url="{{ hijack_url }}">
     {% if is_user_admin %}
-      {% trans 'hijack'|upper %}
+      {% translate 'impersonate'|capfirst context 'verb' %}
     {% else %}
-      {% blocktrans %}impersonate {{ username }}{% endblocktrans %}
+      {% blocktranslate trimmed %}
+        impersonate {{ username }}
+      {% endblocktranslate %}
     {% endif %}
   </button>
 {% endif %}
 ```
+
+The admin button template is rendered without a request context to avoid running
+project-level context processors once per changelist row. The `request` object is
+still available as a regular template variable. If your custom template needs
+additional values, override `get_hijack_button_context()`.
 
 ## Settings
 

--- a/hijack/contrib/admin/admin.py
+++ b/hijack/contrib/admin/admin.py
@@ -1,6 +1,8 @@
 from django import forms
 from django.shortcuts import resolve_url
 from django.template.loader import render_to_string
+from django.urls import reverse
+from django.utils.module_loading import import_string
 from django.utils.translation import gettext_lazy as _
 
 from hijack.conf import settings
@@ -34,6 +36,20 @@ class HijackUserAdminMixin:
             success_url = obj
         return resolve_url(success_url)
 
+    def get_hijack_button_context(self, request, obj):
+        """Return context for the hijack admin button."""
+        user = self.get_hijack_user(obj)
+        can_hijack = import_string(settings.HIJACK_PERMISSION_CHECK)
+        return {
+            "request": request,
+            "another_user": user,
+            "can_hijack": can_hijack(hijacker=request.user, hijacked=user),
+            "username": str(user),
+            "is_user_admin": self.model is type(user),
+            "next": self.get_hijack_success_url(request, obj),
+            "hijack_url": reverse("hijack:acquire"),
+        }
+
     def hijack_button(self, request, obj):
         """
         Render hijack button.
@@ -42,17 +58,9 @@ class HijackUserAdminMixin:
         to ensure deliberate action. However, the name is omitted in the user admin,
         as the table layout suggests that the button targets the current user.
         """
-        user = self.get_hijack_user(obj)
         return render_to_string(
             "hijack/contrib/admin/button.html",
-            {
-                "request": request,
-                "another_user": user,
-                "username": str(user),
-                "is_user_admin": self.model is type(user),
-                "next": self.get_hijack_success_url(request, obj),
-            },
-            request=request,
+            self.get_hijack_button_context(request, obj),
         )
 
     def get_changelist_instance(self, request):

--- a/hijack/contrib/admin/templates/hijack/contrib/admin/button.html
+++ b/hijack/contrib/admin/templates/hijack/contrib/admin/button.html
@@ -1,8 +1,8 @@
-{% load i18n l10n hijack %}
+{% load i18n l10n %}
 
-{% if request.user|can_hijack:another_user %}
+{% if can_hijack %}
   <button type="button" class="button" data-hijack-user="{{ another_user.pk|unlocalize }}"
-          data-hijack-next="{{ next }}" data-hijack-url="{% url 'hijack:acquire' %}">
+          data-hijack-next="{{ next }}" data-hijack-url="{{ hijack_url }}">
     {% if is_user_admin %}
       {% translate 'impersonate'|capfirst context 'verb' %}
     {% else %}

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,9 +1,12 @@
 import logging
+from collections import Counter
+from contextlib import contextmanager
 from unittest.mock import MagicMock
 
 import pytest
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
+from django.template.context import RequestContext
 from django.urls import reverse
 
 from hijack.contrib.admin import HijackUserAdminMixin
@@ -54,6 +57,47 @@ class TestHijackUserAdminMixin:
         response = admin_client.get(url)
         assert response.status_code == 200
         assert b"impersonate admin" in response.content
+
+    def test_get_hijack_button_context(self, rf, admin_user):
+        request = rf.get("/")
+        request.user = admin_user
+        hijack_admin = HijackUserAdminMixin()
+        hijack_admin.model = CustomUser
+
+        context = hijack_admin.get_hijack_button_context(request, admin_user)
+
+        assert context["request"] is request
+        assert context["another_user"] == admin_user
+        assert context["can_hijack"] is True
+        assert context["username"] == str(admin_user)
+        assert context["is_user_admin"] is True
+        assert context["next"] == "/accounts/profile/"
+        assert context["hijack_url"] == reverse("hijack:acquire")
+
+    def test_user_admin_does_not_render_hijack_button_with_request_context(
+        self, admin_client, monkeypatch
+    ):
+        for index in range(3):
+            CustomUser.objects.create(username=f"user-{index}")
+
+        rendered_templates = []
+        original_bind_template = RequestContext.bind_template
+
+        @contextmanager
+        def bind_template_spy(context, template):
+            origin = getattr(template, "origin", None)
+            rendered_templates.append(getattr(origin, "template_name", None) or "")
+            with original_bind_template(context, template):
+                yield
+
+        monkeypatch.setattr(RequestContext, "bind_template", bind_template_spy)
+
+        url = reverse("admin:test_app_customuser_changelist")
+        response = admin_client.get(url)
+
+        assert response.status_code == 200
+        counts = Counter(rendered_templates)
+        assert counts["hijack/contrib/admin/button.html"] == 0
 
     def test_get_hijack_success_url__obj_absolute_url(self, rf):
         obj = Post()


### PR DESCRIPTION
## Summary
- build the admin hijack button context in Python
- render the admin button without a RequestContext
- avoid running project context processors once per admin changelist row
- add regression coverage and update customization docs

## Tests
- python -m pytest -q
- python -m ruff check .
- python -m ruff format --check .